### PR TITLE
fix some bugs

### DIFF
--- a/src/main/java/es/degrassi/mmreborn/common/crafting/requirement/RequirementFluid.java
+++ b/src/main/java/es/degrassi/mmreborn/common/crafting/requirement/RequirementFluid.java
@@ -105,8 +105,8 @@ public class RequirementFluid implements IRequirement<FluidComponent> {
   private CraftingResult errorInput(int amount, FluidStack found, int amountFound) {
     return CraftingResult.error(Component.translatable(
         "craftcheck.failure.fluid.input",
-        Component.translatable("%sx %s", amount, required.asFluidStack().getHoverName()),
-        Component.translatable("%sx %s", amountFound, found.getHoverName())
+        amount, required.asFluidStack().getHoverName(),
+        amountFound, found.getHoverName()
     ));
   }
 

--- a/src/main/java/es/degrassi/mmreborn/common/machine/component/EnergyComponent.java
+++ b/src/main/java/es/degrassi/mmreborn/common/machine/component/EnergyComponent.java
@@ -47,12 +47,14 @@ public class EnergyComponent extends MachineComponent<IEnergyHandler> {
 
           @Override
           public void setCanExtract(boolean b) {
-
+            handler.setCanExtract(b);
+            comp.handler.setCanExtract(b);
           }
 
           @Override
           public void setCanInsert(boolean b) {
-
+            handler.setCanExtract(b);
+            comp.handler.setCanExtract(b);
           }
 
           @Override


### PR DESCRIPTION
- Fix: Cannot use energy for crafting
- 修复：无法使用能源进行合成
The process is still governed by the transmission rate limit defined in the configuration file. Synthesis can only occur normally if the energy consumption per tick in the recipe is below this transmission rate limit.
这依然会受到配置文件关于传输速率的限制，只有配方中每tick能源消耗小于配置文件中的传输速率限制才能正常合成
Before
修复前
![image](https://github.com/user-attachments/assets/5cd4f6e1-6f4c-42c9-9e34-fade6346d8cf)
After
修复后
![image](https://github.com/user-attachments/assets/c79579e3-6318-4751-8774-4b3df06b1a66)

- Fix: text not formatting
- 修复：文本格式化错误
![image](https://github.com/user-attachments/assets/74c8573f-2f5c-4e1d-9c51-a3f3893cfa15)

