### PR TITLE
Tick acceleration optimisations

### DIFF
--- a/src/main/java/es/degrassi/mmreborn/common/entity/MachineControllerEntity.java
+++ b/src/main/java/es/degrassi/mmreborn/common/entity/MachineControllerEntity.java
@@ -28,6 +28,7 @@ import es.degrassi.mmreborn.common.network.server.SUpdateCraftingStatusPacket;
 import es.degrassi.mmreborn.common.registration.EntityRegistration;
 import es.degrassi.mmreborn.common.util.RedstoneHelper;
 import es.degrassi.mmreborn.common.util.SoundManager;
+import es.degrassi.mmreborn.common.util.Utils;
 import lombok.Getter;
 import lombok.Setter;
 import net.minecraft.MethodsReturnNonnullByDefault;
@@ -67,6 +68,9 @@ public class MachineControllerEntity extends BlockEntityRestrictedTick implement
   private final MachineProcessor processor;
   private int lastFocus;
   private SoundManager soundManager;
+
+  private final long tickOffset = Utils.RAND.nextLong(0, Long.MAX_VALUE);
+  private long lastCheckTick;
 
   public MachineControllerEntity(BlockPos pos, BlockState state) {
     super(EntityRegistration.CONTROLLER.get(), pos, state);
@@ -187,24 +191,28 @@ public class MachineControllerEntity extends BlockEntityRestrictedTick implement
   }
 
   public void checkStructure(boolean immediate) {
-    if (immediate || level.getGameTime() % MMRConfig.get().checkStructureTicks.get() == 0) {
-      if (this.getFoundMachine() != DynamicMachine.DUMMY) {
-        if (!getFoundMachine().getPattern().match(getLevel(), getBlockPos(), getBlockState().getValue(BlockStateProperties.HORIZONTAL_FACING))) {
-          distributeCasingColor(true);
-          setStatus(MachineStatus.MISSING_STRUCTURE);
-        } else {
-          distributeCasingColor(false);
-          componentManager.updateComponents(false);
-          if (!status.isCrafting()) {
-            setStatus(MachineStatus.IDLE);
-          } else {
-            setStatus(status);
-          }
-        }
-        setRequestModelUpdate(true);
-        setChanged();
+    if (this.getFoundMachine() == DynamicMachine.DUMMY)
+      return;
+    long gameTime = getLevel().getGameTime();
+    if (!Utils.shouldRunPeriodicCheck(immediate, gameTime, lastCheckTick, tickOffset,
+        MMRConfig.get().checkStructureTicks.get()))
+      return;
+    lastCheckTick = gameTime;
+    if (!getFoundMachine().getPattern().match(getLevel(), getBlockPos(),
+        getBlockState().getValue(BlockStateProperties.HORIZONTAL_FACING))) {
+      distributeCasingColor(true);
+      setStatus(MachineStatus.MISSING_STRUCTURE);
+    } else {
+      distributeCasingColor(false);
+      componentManager.updateComponents(false);
+      if (!status.isCrafting()) {
+        setStatus(MachineStatus.IDLE);
+      } else {
+        setStatus(status);
       }
     }
+    setRequestModelUpdate(true);
+    setChanged();
   }
 
   public void distributeCasingColor(boolean default_, BlockPos... poss) {

--- a/src/main/java/es/degrassi/mmreborn/common/manager/ComponentManager.java
+++ b/src/main/java/es/degrassi/mmreborn/common/manager/ComponentManager.java
@@ -23,6 +23,7 @@ import es.degrassi.mmreborn.common.machine.MachineComponent;
 import es.degrassi.mmreborn.common.machine.component.FunctionComponent;
 import es.degrassi.mmreborn.common.machine.component.ItemComponent;
 import es.degrassi.mmreborn.common.machine.component.ParallelComponent;
+import es.degrassi.mmreborn.common.util.Utils;
 import lombok.Getter;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.HolderLookup;
@@ -51,6 +52,10 @@ public class ComponentManager implements INBTSerializable<CompoundTag>, ISyncabl
   private final Map<ComponentType, Map<IOType, List<MachineComponent<?>>>> foundComponentsValues = Maps.newHashMap();
   private final Map<BlockPos, List<ModifierReplacement>> foundModifiers = Maps.newHashMap();
 
+  private final long tickOffset = Utils.RAND.nextLong(0, Long.MAX_VALUE);
+  private long lastComponentsCheckTick;
+  private long lastModifiersCheckTick;
+
   public ComponentManager(MachineControllerEntity entity) {
     this.controller = entity;
   }
@@ -62,25 +67,37 @@ public class ComponentManager implements INBTSerializable<CompoundTag>, ISyncabl
   }
 
   public final void updateModifiers(boolean force) {
-    if (controller.getFoundMachine() == DynamicMachine.DUMMY) return;
-    if (controller.getLevel() == null) return;
-    if (force || controller.getLevel().getGameTime() % MMRConfig.get().checkStructureTicks.get() == 0) {
-      foundModifiers.clear();
-      foundModifiers.putAll(gatherModifiers());
-    }
+    if (controller.getFoundMachine() == DynamicMachine.DUMMY)
+      return;
+    Level level = controller.getLevel();
+    if (level == null)
+      return;
+    long gameTime = level.getGameTime();
+    if (!Utils.shouldRunPeriodicCheck(force, gameTime, lastModifiersCheckTick, tickOffset,
+        MMRConfig.get().checkStructureTicks.get()))
+      return;
+    lastModifiersCheckTick = gameTime;
+    foundModifiers.clear();
+    foundModifiers.putAll(gatherModifiers());
     controller.setChanged();
   }
 
   public final void updateComponents(boolean force) {
-    if (controller.getFoundMachine() == DynamicMachine.DUMMY) return;
-    if (controller.getLevel() == null) return;
-    if (force || controller.getLevel().getGameTime() % 20 == 0) {
-      reset();
-      foundComponents.putAll(gatherComponents());
-      foundComponentsValues.putAll(filter());
-      updateModifiers(force);
-      controller.getProcessor().setMachineInventoryChanged();
-    }
+    if (controller.getFoundMachine() == DynamicMachine.DUMMY)
+      return;
+    Level level = controller.getLevel();
+    if (level == null)
+      return;
+    long gameTime = level.getGameTime();
+    if (!Utils.shouldRunPeriodicCheck(force, gameTime, lastComponentsCheckTick, tickOffset,
+        MMRConfig.get().checkStructureTicks.get()))
+      return;
+    lastComponentsCheckTick = gameTime;
+    reset();
+    foundComponents.putAll(gatherComponents());
+    foundComponentsValues.putAll(filter());
+    updateModifiers(force);
+    controller.getProcessor().setMachineInventoryChanged();
     controller.setChanged();
   }
 

--- a/src/main/java/es/degrassi/mmreborn/common/util/Utils.java
+++ b/src/main/java/es/degrassi/mmreborn/common/util/Utils.java
@@ -66,4 +66,17 @@ public class Utils {
   public static long clamp(long value, long min, long max) {
     return value < min ? min : Math.min(value, max);
   }
+
+  public static boolean shouldRunPeriodicCheck(boolean immediate, long gameTime, long lastGameTime, long offset,
+      long period) {
+    if (lastGameTime == gameTime)
+      return false;
+    if (immediate)
+      return true;
+    long roundGameTime = gameTime % period;
+    long roundOffset = offset % period;
+    if ((roundGameTime + roundOffset) % period != 0)
+      return false;
+    return true;
+  }
 }


### PR DESCRIPTION
This PR proposes two changes that would make tick acceleration be more friendly to modular machines:

1. Run periodic checks (checks that look at the level time) at most once per tick.
  - Tick accelerators like Soul Surge or Time in a bottle run the controller `tick` multiple times for the same level game time.
  - Periodic checks that use `gameTime % period == 0` would trigger multiple times in the same tick, because even though `tick` is called multiple times, `gameTime % period == 0` is true for all of these calls.
2. Give each controller an individual offset.
  - The more controllers are in a level, the more the `gameTime % period == 0` ticks are going to take, as periodic checks run for all of the machines in the same tick. This make the MSPT slightly large for these ticks.
  - We can avoid this by relaxing the check to `(gameTime + offset) % period == 0`, for a random offset for each controller. The checks still run every `period` ticks, but each controller has its own offset in order to avoid piling the same tick.

I've tested these changes with an absurd tick acceleration (2048x) and had no TPS impact at all during recipe processing.