### PR TITLE
Avoid loading client classes server side

### DIFF
--- a/src/main/java/es/degrassi/mmreborn/common/manager/ComponentManager.java
+++ b/src/main/java/es/degrassi/mmreborn/common/manager/ComponentManager.java
@@ -8,13 +8,13 @@ import es.degrassi.mmreborn.api.crafting.ICraftingContext;
 import es.degrassi.mmreborn.api.crafting.requirement.IRequirement;
 import es.degrassi.mmreborn.api.network.ISyncable;
 import es.degrassi.mmreborn.api.network.ISyncableStuff;
-import es.degrassi.mmreborn.client.ModularMachineryRebornClient;
 import es.degrassi.mmreborn.common.crafting.ComponentType;
 import es.degrassi.mmreborn.common.crafting.modifier.ModifierReplacement;
 import es.degrassi.mmreborn.common.crafting.modifier.RecipeModifier;
 import es.degrassi.mmreborn.common.crafting.requirement.RequirementType;
 import es.degrassi.mmreborn.common.data.MMRConfig;
 import es.degrassi.mmreborn.common.entity.MachineControllerEntity;
+import es.degrassi.mmreborn.common.entity.ParallelHatchEntity;
 import es.degrassi.mmreborn.common.entity.base.MachineComponentEntity;
 import es.degrassi.mmreborn.common.entity.base.TileItemBus;
 import es.degrassi.mmreborn.common.machine.DynamicMachine;
@@ -201,8 +201,14 @@ public class ComponentManager implements INBTSerializable<CompoundTag>, ISyncabl
     for (BlockPos potentialPosition : filteredMap.keySet()) {
       BlockPos realPos = controllerPos.offset(potentialPosition);
       try {
-        return Optional.of(ModularMachineryRebornClient.getClientSideParallelHatchEntity(realPos).provideComponent());
-      } catch (Exception ignored) {}
+        if (level.getBlockEntity(realPos) instanceof ParallelHatchEntity entity) {
+          ParallelComponent component = entity.provideComponent();
+          if (component == null)
+            continue;
+          return Optional.of(component);
+        }
+      } catch (Exception ignored) {
+      }
     }
     return Optional.empty();
   }
@@ -218,11 +224,16 @@ public class ComponentManager implements INBTSerializable<CompoundTag>, ISyncabl
     for (BlockPos potentialPosition : filteredMap.keySet()) {
       BlockPos realPos = controllerPos.offset(potentialPosition);
       try {
-        TileItemBus entity = ModularMachineryRebornClient.getClientSideItemBusEntity(realPos);
-        if (!entity.getIoType().equals(mode)) continue;
-        if (entity.provideComponent() == null) continue;
-        components.add(entity.provideComponent());
-      } catch (Exception ignored) {}
+        if (level.getBlockEntity(realPos) instanceof TileItemBus entity) {
+          if (!entity.getIoType().equals(mode))
+            continue;
+          ItemComponent component = entity.provideComponent();
+          if (component == null)
+            continue;
+          components.add(component);
+        }
+      } catch (Exception ignored) {
+      }
     }
     if (components.isEmpty())
       return Optional.empty();


### PR DESCRIPTION
This PR fixes the following log spam that occurs on server load and each time someone opens a controller UI, while running on a dedicated server:

```
[19:33:13] [Server thread/ERROR] [ne.ne.fm.co.as.RuntimeDistCleaner/DISTXFORM]: Attempted to load class net/minecraft/client/gui/screens/inventory/tooltip/ClientTooltipComponent for invalid dist DEDICATED_SERVER
[19:33:13] [Server thread/ERROR] [ne.ne.fm.co.as.RuntimeDistCleaner/DISTXFORM]: Attempted to load class net/minecraft/client/gui/screens/inventory/tooltip/ClientTooltipComponent for invalid dist DEDICATED_SERVER
[19:33:13] [Server thread/ERROR] [ne.ne.fm.co.as.RuntimeDistCleaner/DISTXFORM]: Attempted to load class net/minecraft/client/gui/screens/inventory/tooltip/ClientTooltipComponent for invalid dist DEDICATED_SERVER
[19:33:13] [Server thread/ERROR] [ne.ne.fm.co.as.RuntimeDistCleaner/DISTXFORM]: Attempted to load class net/minecraft/client/gui/screens/inventory/tooltip/ClientTooltipComponent for invalid dist DEDICATED_SERVER
[19:33:13] [Server thread/ERROR] [ne.ne.fm.co.as.RuntimeDistCleaner/DISTXFORM]: Attempted to load class net/minecraft/client/gui/screens/inventory/tooltip/ClientTooltipComponent for invalid dist DEDICATED_SERVER
[19:33:13] [Server thread/ERROR] [ne.ne.fm.co.as.RuntimeDistCleaner/DISTXFORM]: Attempted to load class net/minecraft/client/gui/screens/inventory/tooltip/ClientTooltipComponent for invalid dist DEDICATED_SERVER
[19:33:13] [Server thread/ERROR] [ne.ne.fm.co.as.RuntimeDistCleaner/DISTXFORM]: Attempted to load class net/minecraft/client/gui/screens/inventory/tooltip/ClientTooltipComponent for invalid dist DEDICATED_SERVER
[19:33:13] [Server thread/ERROR] [ne.ne.fm.co.as.RuntimeDistCleaner/DISTXFORM]: Attempted to load class net/minecraft/client/gui/screens/inventory/tooltip/ClientTooltipComponent for invalid dist DEDICATED_SERVER
[19:33:13] [Server thread/ERROR] [ne.ne.fm.co.as.RuntimeDistCleaner/DISTXFORM]: Attempted to load class net/minecraft/client/gui/screens/inventory/tooltip/ClientTooltipComponent for invalid dist DEDICATED_SERVER
[19:33:13] [Server thread/ERROR] [ne.ne.fm.co.as.RuntimeDistCleaner/DISTXFORM]: Attempted to load class net/minecraft/client/gui/screens/inventory/tooltip/ClientTooltipComponent for invalid dist DEDICATED_SERVER
[19:33:13] [Server thread/ERROR] [ne.ne.fm.co.as.RuntimeDistCleaner/DISTXFORM]: Attempted to load class net/minecraft/client/gui/screens/inventory/tooltip/ClientTooltipComponent for invalid dist DEDICATED_SERVER
[19:33:13] [Server thread/ERROR] [ne.ne.fm.co.as.RuntimeDistCleaner/DISTXFORM]: Attempted to load class net/minecraft/client/gui/screens/inventory/tooltip/ClientTooltipComponent for invalid dist DEDICATED_SERVER
[19:33:13] [Server thread/ERROR] [ne.ne.fm.co.as.RuntimeDistCleaner/DISTXFORM]: Attempted to load class net/minecraft/client/gui/screens/inventory/tooltip/ClientTooltipComponent for invalid dist DEDICATED_SERVER
[19:33:13] [Server thread/ERROR] [ne.ne.fm.co.as.RuntimeDistCleaner/DISTXFORM]: Attempted to load class net/minecraft/client/gui/screens/inventory/tooltip/ClientTooltipComponent for invalid dist DEDICATED_SERVER
[19:33:13] [Server thread/ERROR] [ne.ne.fm.co.as.RuntimeDistCleaner/DISTXFORM]: Attempted to load class net/minecraft/client/gui/screens/inventory/tooltip/ClientTooltipComponent for invalid dist DEDICATED_SERVER
[19:33:13] [Server thread/ERROR] [ne.ne.fm.co.as.RuntimeDistCleaner/DISTXFORM]: Attempted to load class net/minecraft/client/gui/screens/inventory/tooltip/ClientTooltipComponent for invalid dist DEDICATED_SERVER
[19:33:13] [Server thread/ERROR] [ne.ne.fm.co.as.RuntimeDistCleaner/DISTXFORM]: Attempted to load class net/minecraft/client/gui/screens/inventory/tooltip/ClientTooltipComponent for invalid dist DEDICATED_SERVER
[19:33:13] [Server thread/ERROR] [ne.ne.fm.co.as.RuntimeDistCleaner/DISTXFORM]: Attempted to load class net/minecraft/client/gui/screens/inventory/tooltip/ClientTooltipComponent for invalid dist DEDICATED_SERVER
[19:33:13] [Server thread/ERROR] [ne.ne.fm.co.as.RuntimeDistCleaner/DISTXFORM]: Attempted to load class net/minecraft/client/gui/screens/inventory/tooltip/ClientTooltipComponent for invalid dist DEDICATED_SERVER
[19:33:13] [Server thread/ERROR] [ne.ne.fm.co.as.RuntimeDistCleaner/DISTXFORM]: Attempted to load class net/minecraft/client/gui/screens/inventory/tooltip/ClientTooltipComponent for invalid dist DEDICATED_SERVER
[19:33:13] [Server thread/ERROR] [ne.ne.fm.co.as.RuntimeDistCleaner/DISTXFORM]: Attempted to load class net/minecraft/client/gui/screens/inventory/tooltip/ClientTooltipComponent for invalid dist DEDICATED_SERVER
[19:33:13] [Server thread/ERROR] [ne.ne.fm.co.as.RuntimeDistCleaner/DISTXFORM]: Attempted to load class net/minecraft/client/gui/screens/inventory/tooltip/ClientTooltipComponent for invalid dist DEDICATED_SERVER
[19:33:13] [Server thread/ERROR] [ne.ne.fm.co.as.RuntimeDistCleaner/DISTXFORM]: Attempted to load class net/minecraft/client/gui/screens/inventory/tooltip/ClientTooltipComponent for invalid dist DEDICATED_SERVER
[19:33:13] [Server thread/ERROR] [ne.ne.fm.co.as.RuntimeDistCleaner/DISTXFORM]: Attempted to load class net/minecraft/client/gui/screens/inventory/tooltip/ClientTooltipComponent for invalid dist DEDICATED_SERVER
[19:33:13] [Server thread/ERROR] [ne.ne.fm.co.as.RuntimeDistCleaner/DISTXFORM]: Attempted to load class net/minecraft/client/gui/screens/inventory/tooltip/ClientTooltipComponent for invalid dist DEDICATED_SERVER
```

This also fixes a very long tick MSPT (500ms) that was associated with this log spam.