### PR TITLE
Preview of the multiblock respecting size

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,8 +6,8 @@ minecraft_version=1.21.1
 archives_base_name=modular_machinery_reborn
 maven_group=es.degrassi
 minecraft_version_range=[1.21, 1.22)
-neo_version=21.1.199
-neo_version_range=[21.1.199,)
+neo_version=21.1.216
+neo_version_range=[21.1.216,)
 loader_version_range=[4,)
 
 parchment_minecraft_version=1.21.1
@@ -36,7 +36,7 @@ almostunified_version=1.21.1-1.2.5
 mekanism_version=1.21.1-10.7.16.82
 athena_version=4.0.3
 yoga_version=1.0.0
-ldlib2_version=2.1.6.a
+ldlib2_version=2.2.10
 lombok_version=1.18.42
 
 # Experience fluid mods by default

--- a/src/main/java/es/degrassi/mmreborn/common/integration/xei/MultiblockRecipe.java
+++ b/src/main/java/es/degrassi/mmreborn/common/integration/xei/MultiblockRecipe.java
@@ -50,14 +50,23 @@ public class MultiblockRecipe {
         .stream()
         .filter(stacks -> !stacks.isEmpty() && !stacks.stream().allMatch(ItemStack::isEmpty))
         .forEach(stacks -> {
-          var slot = new ItemSlot();
-          requiredItems.put(slot
-                  .setItem(MultiblockScene.blockTimer.getOrDefault(stacks, ItemStack.EMPTY))
-                  .xeiRecipeIngredient(IngredientIO.INPUT)
-                  .xeiRecipeSlot(),
-              stacks
-          );
-        });
+            var slot = new UnlimitedItemSlot(UnlimitedItemSlot.createInfiniteSlot());
+                    
+            ItemStack displayStack = MultiblockScene.blockTimer.getOrDefault(stacks, stacks.get(0)).copy();
+            if(displayStack.isEmpty())
+            {
+                displayStack = stacks.get(0).copy();
+            }
+            displayStack.setCount(stacks.get(0).getCount());
+
+            requiredItems.put(slot
+                              .setItem(displayStack)
+                              .xeiRecipeIngredient(IngredientIO.INPUT)
+                              .xeiRecipeSlot(),
+                          stacks
+            );
+      });
+    
     var blockLabel = new Label().setText("");
     AtomicReference<BlockPos> selectedPos = new AtomicReference<>(null);
     return ModularUI.of(UI.of(new UIElement()

--- a/src/main/java/es/degrassi/mmreborn/common/integration/xei/UnlimitedItemSlot.java
+++ b/src/main/java/es/degrassi/mmreborn/common/integration/xei/UnlimitedItemSlot.java
@@ -1,0 +1,95 @@
+package es.degrassi.mmreborn.common.integration.xei;
+
+import com.lowdragmc.lowdraglib2.gui.ui.elements.ItemSlot;
+
+import net.minecraft.world.SimpleContainer;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.ItemStack;
+
+import com.lowdragmc.lowdraglib2.gui.ui.rendering.GUIContext;
+import com.lowdragmc.lowdraglib2.gui.util.DrawerHelper;
+
+public class UnlimitedItemSlot extends ItemSlot
+{
+    private ItemStack stack = ItemStack.EMPTY;
+
+    public UnlimitedItemSlot(Slot slot)
+    {
+        super(slot);
+    }
+
+    @Override
+    public ItemStack getValue()
+    {
+        return this.stack;
+    }
+
+    @Override
+    public ItemSlot setValue(ItemStack value, boolean notify)
+    {
+        if(value == null)
+        {
+            value = ItemStack.EMPTY;
+        }
+
+        if(ItemStack.matches(value, this.stack))
+        {
+            return this;
+        }
+
+        this.stack = value;
+
+        ItemStack clamped = this.stack.copy();
+        if(!clamped.isEmpty() && clamped.getCount() > 64)
+        {
+            clamped.setCount(64);
+        }
+
+        return super.setValue(clamped, notify);
+    }
+
+    @Override
+    public ItemSlot setItem(ItemStack itemStack)
+    {
+        return this.setValue(itemStack, true);
+    }
+
+    @Override
+    public ItemSlot setItem(ItemStack itemStack, boolean notify)
+    {
+        return this.setValue(itemStack, notify);
+    }
+
+    @Override
+    protected void drawItemStack(GUIContext guiContext, ItemStack itemStack)
+    {
+        String text = this.stack.getCount() > 1 ? String.valueOf(this.stack.getCount()) : null;
+        DrawerHelper.drawItemStack(guiContext.graphics, this.stack, 0, 0, guiContext.elementColor, text);
+    }
+
+    public static Slot createInfiniteSlot()
+    {
+        SimpleContainer container = new SimpleContainer(1) {
+            
+            @Override
+            public int getMaxStackSize()
+            {
+                return Integer.MAX_VALUE;
+            }
+        };
+
+        return new Slot(container, 0, 0, 0) {
+            @Override
+            public int getMaxStackSize()
+            {
+                return Integer.MAX_VALUE;
+            }
+
+            @Override
+            public int getMaxStackSize(ItemStack stack)
+            {
+                return Integer.MAX_VALUE;
+            }
+        };
+    }
+}


### PR DESCRIPTION
<img width="832" height="937" alt="image" src="https://github.com/user-attachments/assets/48855258-fa94-42c0-bfd2-4e8c51026c90" />

So basically, we have to invent our own slots and fake a few things.

Needed to bump the neo version and the ldlib2 version, picking the lastest release on cf, since from the last version to the new one, there was one that added the custom text part
